### PR TITLE
Permission requests can now only be resolved one at a time

### DIFF
--- a/lib/src/features/permissions/use_cases/request_permission.dart
+++ b/lib/src/features/permissions/use_cases/request_permission.dart
@@ -1,16 +1,21 @@
+import 'dart:async';
+
 import 'package:dartz/dartz.dart';
 import 'package:get_it/get_it.dart';
 import 'package:kuama_dart_domain/src/features/permissions/entities/permission.dart';
 import 'package:kuama_dart_domain/src/features/permissions/repositories/permission_repository.dart';
 import 'package:kuama_dart_domain/src/shared/errors/failure.dart';
+import 'package:kuama_dart_domain/src/shared/locker.dart';
 import 'package:kuama_dart_domain/src/shared/use_case/use_case.dart';
 
 /// Requires permission
 class RequestPermission extends UseCase<Permission, PermissionStatus> {
   final PermissionRepository permissionsRepo = GetIt.I();
 
+  static final _locker = Locker();
+
   @override
   Stream<Either<Failure, PermissionStatus>> tryCall(Permission permission) async* {
-    yield* permissionsRepo.request(permission).toRight();
+    yield* permissionsRepo.request(permission).sync(_locker).toRight<Failure>();
   }
 }

--- a/lib/src/features/permissions/use_cases/update_can_ask_permission.dart
+++ b/lib/src/features/permissions/use_cases/update_can_ask_permission.dart
@@ -16,7 +16,7 @@ class UpdateCanAskPermissionParams extends ParamsBase {
 abstract class UpdateCanAskPermission extends UseCase<UpdateCanAskPermissionParams, bool> {
   UpdateCanAskPermission();
 
-  factory UpdateCanAskPermission.factory() = _PreferencesUpdateCanAskPermission;
+  factory UpdateCanAskPermission.preferences() = _PreferencesUpdateCanAskPermission;
 }
 
 /// [UpdateCanAskPermission] Use the repository [PermissionPreferencesRepository]

--- a/lib/src/shared/locker.dart
+++ b/lib/src/shared/locker.dart
@@ -1,0 +1,36 @@
+import 'dart:async';
+
+typedef VoidCallback = void Function();
+
+/// Allows you to make code asynchronous. Use it only with streams
+/// Prefer to use the synchronized package whenever possible
+class Locker {
+  Future<dynamic>? _last;
+
+  Future<VoidCallback> lock() {
+    final locker = Completer.sync();
+    final unLock = () {
+      if (identical(_last, locker.future)) {
+        _last = null;
+      }
+      locker.complete();
+    };
+
+    final previous = _last;
+    _last = locker.future;
+
+    if (previous == null) {
+      return Future.value(unLock);
+    } else {
+      return previous.then((_) => unLock);
+    }
+  }
+}
+
+extension StreamSync<T> on Stream<T> {
+  Stream<T> sync(Locker locker) async* {
+    final unLock = await locker.lock();
+    yield* this;
+    unLock();
+  }
+}

--- a/test/shared/locker_test.dart
+++ b/test/shared/locker_test.dart
@@ -1,0 +1,48 @@
+import 'dart:async';
+
+import 'package:kuama_dart_domain/src/shared/locker.dart';
+import 'package:test/expect.dart';
+import 'package:test/scaffolding.dart';
+
+void main() {
+  late Locker locker;
+
+  setUp(() {
+    locker = Locker();
+  });
+
+  group('Test Locker', () {
+    test('Test synchronization', () async {
+      final debugLabels = StreamController();
+
+      String l(int workNumber, _Tag tag) => '$workNumber-$tag';
+
+      void t(int workNumber) async {
+        final unLockDone = locker.lock();
+        debugLabels.add(l(workNumber, _Tag.waitLock));
+        final unLock = await unLockDone;
+        debugLabels.add(l(workNumber, _Tag.working));
+        await Future.delayed(Duration(milliseconds: 100));
+        debugLabels.add(l(workNumber, _Tag.unLocked));
+        unLock();
+      }
+
+      t(1);
+      t(2);
+
+      await expectLater(
+        debugLabels.stream,
+        emitsInOrder([
+          l(1, _Tag.waitLock),
+          l(2, _Tag.waitLock),
+          l(1, _Tag.working),
+          l(1, _Tag.unLocked),
+          l(2, _Tag.working),
+          l(2, _Tag.unLocked),
+        ]),
+      );
+    });
+  });
+}
+
+enum _Tag { waitLock, working, unLocked }


### PR DESCRIPTION
- Nomenclature fixed
- Permission requests can now only be resolved one at a time